### PR TITLE
Fiducial List Support

### DIFF
--- a/TOMAAT/utils/ui.py
+++ b/TOMAAT/utils/ui.py
@@ -84,6 +84,24 @@ class ScalarVolumeWidget(slicer.qMRMLNodeComboBox):
         sliceNode = sliceLogic.GetSliceNode()
         sliceNode.SetSliceVisible(True)
 
+class MarkupsFiducialWidget(slicer.qMRMLNodeComboBox):
+    def __init__(self, destination):
+        super(MarkupsFiducialWidget, self).__init__()
+
+        self.destination = destination
+
+        self.type = 'MarkupsFiducialWidget'
+
+        self.nodeTypes = ['vtkMRMLMarkupsFiducialNode']
+        self.selectNodeUponCreation = True
+        self.addEnabled = False
+        self.removeEnabled = False
+        self.noneEnabled = False
+        self.showHidden = False
+        self.showChildNodeTypes = False
+        self.setMRMLScene(slicer.mrmlScene)
+        self.setToolTip('Pick fiducial list')
+
 
 class SliderWidget(ctk.ctkSliderWidget):
     def __init__(self, minimum, maximum, destination):


### PR DESCRIPTION
This is an approach to support fiducial list in Slicer for TOMAAT.
It transforms a fiducial list into a string respresentation.
Each point is separated by a semicolon, each actual value is separated by a comma.
See:
<pt1_x>,<pt1_y>,<pt1_z>;<pt2_x>,......