### PR TITLE
Update pip module import for newer Python2 Slicer support.

### DIFF
--- a/TOMAAT/utils/dependencies.py
+++ b/TOMAAT/utils/dependencies.py
@@ -1,15 +1,21 @@
+# import pip main
+try:
+    from pip import main as pipmain
+except:
+    from pip._internal import main as pipmain
+
+# install requests
 try:
   import requests
 except:
-  import pip
-  pip.main(['install','requests'])
+  pipmain(['install','requests'])
   import requests
   pass
 
+# install requests_toolbelt
 try:
   from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 except:
-  import pip
-  pip.main(['install', 'requests_toolbelt'])
+  pipmain(['install', 'requests_toolbelt'])
   from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
   pass


### PR DESCRIPTION
Hi Fausto!

It seems that on newer versions of Slicer the pip.main does not work anymore.
I am using the nightly version 2018-08-04.
This pull request should _hopefully_ fix it.

Cheers,
Johann